### PR TITLE
fix for code wrapping

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ function parse( file, flatten ){
       data[path].title = (title.substr(0,1) === '#')
         ? title.substr(2)
         : title;
-      data[path].body = markup.slice(1).join(' ');
+      data[path].body = markup.slice(1).join('\n');
     } else {
       data[path].body = marked(parsed.body);
     }


### PR DESCRIPTION
Since this was joining on a space rather than a new line, going down this code path makes text inside of a code / pre tag not wrap properly, changing to a new line fixes this.